### PR TITLE
style: 鼠标悬浮在文件上时会显示完整文件名

### DIFF
--- a/src/components/TileViewFileExplorer/FileItem/index.jsx
+++ b/src/components/TileViewFileExplorer/FileItem/index.jsx
@@ -23,6 +23,7 @@ const Index = ({item}) => {
   return (
     <>
       <div
+        title={item.name}
         className={`w-24 h-24 flex flex-col justify-center items-center cursor-pointer duration-200 select-none ${getBgColor(item)}`}>
         <div className="max-w-20 text-3xl">
           {item.is_directory ? '📁' : '📄'}


### PR DESCRIPTION
现在的文件显示方式是图标，遇到比较长的文件名会无法区分是哪个？所以增加了一个悬浮显示完整文件名的功能